### PR TITLE
Cuda support for sampling when surface_id missing

### DIFF
--- a/lab_gatr/transforms.py
+++ b/lab_gatr/transforms.py
@@ -22,7 +22,7 @@ class PointCloudPoolingScales():
     def __call__(self, data: pyg.data.Data) -> Data:
 
         pos = data.pos
-        batch = data.surface_id.long() if hasattr(data, 'surface_id') else torch.zeros(pos.size(0), dtype=torch.long)
+        batch = data.surface_id.long() if hasattr(data, 'surface_id') else torch.zeros(pos.size(0), dtype=torch.long, device=pos.device)
 
         for i, sampling_ratio in enumerate(self.rel_sampling_ratios):
 


### PR DESCRIPTION
### Issue description
Currently when no `surface_id` is provided and `data` object is on GPU, the `PointCloudPoolingScales` breaks with `batch` variable being on the wrong device, namely `cpu`.  Sampling on GPU gives quite a large speedup.

### Fix
Set device of `batch` tensor on creation to be the same as of `pos` tensor.